### PR TITLE
feat: Loader 애니메이션 추가

### DIFF
--- a/react-app/src/components/Loader.jsx
+++ b/react-app/src/components/Loader.jsx
@@ -1,0 +1,62 @@
+import "./LoaderStyle.css"; // CSS 파일 임포트
+
+const Loader = () => {
+  return (
+    <div className="loader-container">
+      <div className="loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row2 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row3 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row4 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row5 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row6 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row7 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row8 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row9 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row10 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row11 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row12 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+      <div className="loader-row13 loader-rowc">
+        <div className="loader-circle loader-c1"></div>
+        <div className="loader-circle loader-c2"></div>
+      </div>
+    </div>
+  );
+};
+
+export default Loader;

--- a/react-app/src/components/LoaderStyle.css
+++ b/react-app/src/components/LoaderStyle.css
@@ -1,0 +1,171 @@
+.loader-circle {
+    border-radius: 50%;
+    width: 10px;
+    height: 10px;
+    background-color: #1e90ff;
+    margin-bottom: 25px;
+    position: relative;
+}
+
+.loader-container {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.loader-rowc {
+    display: inline-block;
+    margin-left: 2px;
+}
+
+.loader-c1 {
+    animation: loader-c1 1.5s linear infinite;
+}
+
+.loader-c2 {
+    animation: loader-c2 1.5s linear infinite;
+    background-color: #3fd1ff;
+}
+
+@keyframes loader-c1 {
+    0% {
+        transform: translateY(0px) scale(1);
+    }
+    25% {
+        transform: translateY(12px) scale(1.5);
+        background-color: #0c87ff;
+        z-index: 10;
+    }
+    50% {
+        transform: translateY(34px) scale(1);
+    }
+    75% {
+        transform: translateY(12px) scale(0.6);
+        background-color: #3a9eff;
+        z-index: 1;
+        opacity: 0.1;
+    }
+    100% {
+        transform: translateY(0px) scale(1);
+    }
+}
+
+@keyframes loader-c2 {
+    0% {
+        transform: translateY(0px) scale(1);
+    }
+    25% {
+        transform: translateY(-12px) scale(0.6);
+        background-color: #75deff;
+        z-index: 1;
+        opacity: 0.1;
+    }
+    50% {
+        transform: translateY(-34px) scale(1);
+    }
+    75% {
+        transform: translateY(-12px) scale(1.5);
+        background-color: #0fc3ff;
+        z-index: 10;
+    }
+    100% {
+        transform: translateY(0px) scale(1);
+    }
+}
+
+.loader-row2 .loader-c1 {
+    animation-delay: 0.1s;
+}
+
+.loader-row2 .loader-c2 {
+    animation-delay: 0.1s;
+}
+
+.loader-row3 .loader-c1 {
+    animation-delay: 0.22s;
+}
+
+.loader-row3 .loader-c2 {
+    animation-delay: 0.22s;
+}
+
+.loader-row4 .loader-c1 {
+    animation-delay: 0.37s;
+}
+
+.loader-row4 .loader-c2 {
+    animation-delay: 0.37s;
+}
+
+.loader-row5 .loader-c1 {
+    animation-delay: 0.49s;
+}
+
+.loader-row5 .loader-c2 {
+    animation-delay: 0.49s;
+}
+
+.loader-row6 .loader-c1 {
+    animation-delay: 0.67s;
+}
+
+.loader-row6 .loader-c2 {
+    animation-delay: 0.67s;
+}
+
+.loader-row7 .loader-c1 {
+    animation-delay: 0.89s;
+}
+
+.loader-row7 .loader-c2 {
+    animation-delay: 0.89s;
+}
+
+.loader-row8 .loader-c1 {
+    animation-delay: 0.95s;
+}
+
+.loader-row8 .loader-c2 {
+    animation-delay: 0.95s;
+}
+
+.loader-row9 .loader-c1 {
+    animation-delay: 1.2s;
+}
+
+.loader-row9 .loader-c2 {
+    animation-delay: 1.2s;
+}
+
+.loader-row10 .loader-c1 {
+    animation-delay: 1.45s;
+}
+
+.loader-row10 .loader-c2 {
+    animation-delay: 1.45s;
+}
+
+.loader-row11 .loader-c1 {
+    animation-delay: 1.62s;
+}
+
+.loader-row11 .loader-c2 {
+    animation-delay: 1.62s;
+}
+
+.loader-row12 .loader-c1 {
+    animation-delay: 1.88s;
+}
+
+.loader-row12 .loader-c2 {
+    animation-delay: 1.88s;
+}
+
+.loader-row13 .loader-c1 {
+    animation-delay: 2s;
+}
+
+.loader-row13 .loader-c2 {
+    animation-delay: 2s;
+}

--- a/react-app/src/components/layout/AnalysisPage.module.css
+++ b/react-app/src/components/layout/AnalysisPage.module.css
@@ -55,3 +55,4 @@
   margin-bottom: 1rem;
 }
 
+/* 로딩 애니메이션 관련 */

--- a/react-app/src/pages/AnalysisPage.jsx
+++ b/react-app/src/pages/AnalysisPage.jsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/Card"
 import '../components/layout/AnalysisPage.module.css';
 import Navbar from '../components/layout/Navbar.jsx';
 import { useEffect, useState } from 'react';
+import Loader from '../components/Loader.jsx'; // 로딩 컴포넌트 임포트
 
 async function getAnalitics() { // fetch 쿼리문
     const res = await fetch("http://localhost:5173/analysis");
@@ -22,10 +23,12 @@ const AnalysisPage = () => {
     const [error, setError] = useState(null); // 에러 상태 선언
     const [selectedData, setSelectedData] = useState(null); // 선택된 뉴스 데이터
     const [displayedSummary, setDisplayedSummary] = useState('');
+    const [loading, setLoading] = useState(true); // 로딩 상태 추가
 
     useEffect(() => {
         const fetchData = async () => {
             try {
+                setLoading(true); // 로딩 시작
                 const analyticsData = await getAnalitics();
                 setData(analyticsData); // 전체 데이터 업데이트
     
@@ -38,7 +41,11 @@ const AnalysisPage = () => {
             } catch (error) {
                 console.error("Error fetching data:", error);
                 setError(error); // 에러 상태 업데이트
-            }
+            } finally {
+              setTimeout(() => {
+                  setLoading(false); // 로딩 종료
+              }, 3000); // 로딩 애니메이션 확인을 위해 약간의 딜레이 추가
+          }
         };
 
         fetchData();
@@ -46,21 +53,33 @@ const AnalysisPage = () => {
 
   console.log(data);
 
+  const handleShowKoreanSummary = () => {
+    setLoading(true); // 로딩 시작
+    setTimeout(() => {
+      setDisplayedSummary(selectedData['summary-kor']); // 한국어 요약 표시
+      setLoading(false); // 로딩 종료
+    }, 500); // 애니메이션 확인을 위한 딜레이 추가
+  };
+
+  const handleShowEnglishSummary = () => {
+    setLoading(true); // 로딩 시작
+    setTimeout(() => {
+      setDisplayedSummary(selectedData.summary); // 영어 요약 표시
+      setLoading(false); // 로딩 종료
+    }, 500);
+  };
+
+  if (loading) {
+    return <Loader />; // 로딩 컴포넌트를 표시
+  }
+
   if (error) {
-      return <div>데이터를 불러오는 중 오류가 발생했습니다: {error.message}</div>;
+    return <div>데이터를 불러오는 중 오류가 발생했습니다: {error.message}</div>;
   }
 
   if (!data) {
       return <div>데이터를 불러오는 중입니다...</div>;
   }
-
-  const handleShowKoreanSummary = () => {
-    setDisplayedSummary(selectedData['summary-kor']); // 한국어 요약 표시
-  };
-
-  const handleShowEnglishSummary = () => {
-    setDisplayedSummary(selectedData.summary); // 영어 요약 표시
-  };
   
   return (
     <div className="min-h-screen bg-background">


### PR DESCRIPTION
## 변경 사항
 분석 차트 페이지에 Loader 애니메이션 추가

## 테스트 실행

- [x]  👍 Yes
- [ ]  🙅 No, Because they are not neaded
- [ ]  🤯 No, Because I needed help with writing tests

### 테스트 결과
<img width="384" alt="스크린샷 2024-11-29 03 03 08" src="https://github.com/user-attachments/assets/07f37e40-ea15-4863-b297-01d8babdc259">

- 페이지 초기 로딩시, 번역하기, 뉴스 요약 버튼 누를시 로딩 애니메이션 추가

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
