### PR TITLE
feat: 신뢰도 50% 미만 기사 경고창 띄우기

### DIFF
--- a/react-app/src/components/ErrorAlert.jsx
+++ b/react-app/src/components/ErrorAlert.jsx
@@ -1,0 +1,45 @@
+import styles from "./ErrorAlert.module.css"; // CSS 모듈 임포트
+import PropTypes from "prop-types"; // PropTypes 임포트
+
+const ErrorAlert = ({ message, onClose }) => {
+  return (
+    <div className={styles.error}>
+      <div className={styles.error__icon}>
+        <svg
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m13 13h-2v-6h2zm0 4h-2v-2h2zm-1-15c-1.3132 0-2.61358.25866-3.82683.7612-1.21326.50255-2.31565 1.23915-3.24424 2.16773-1.87536 1.87537-2.92893 4.41891-2.92893 7.07107 0 2.6522 1.05357 5.1957 2.92893 7.0711.92859.9286 2.03098 1.6651 3.24424 2.1677 1.21325.5025 2.51363.7612 3.82683.7612 2.6522 0 5.1957-1.0536 7.0711-2.9289 1.8753-1.8754 2.9289-4.4189 2.9289-7.0711 0-1.3132-.2587-2.61358-.7612-3.82683-.5026-1.21326-1.2391-2.31565-2.1677-3.24424-.9286-.92858-2.031-1.66518-3.2443-2.16773-1.2132-.50254-2.5136-.7612-3.8268-.7612z"
+            fill="#fff"
+          ></path>
+        </svg>
+      </div>
+      <div className={styles.error__title}>{message}</div>
+      <div className={styles.error__close} onClick={onClose}>
+        <svg
+          height="20"
+          viewBox="0 0 20 20"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m15.8333 5.34166-1.175-1.175-4.6583 4.65834-4.65833-4.65834-1.175 1.175 4.65833 4.65834-4.65833 4.6583 1.175 1.175 4.65833-4.6583 4.6583 4.6583 1.175-1.175-4.6583-4.6583z"
+            fill="#fff"
+          ></path>
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+// PropTypes 정의
+ErrorAlert.propTypes = {
+  message: PropTypes.string.isRequired, // message는 필수 문자열
+  onClose: PropTypes.func.isRequired,   // onClose는 필수 함수
+};
+
+export default ErrorAlert;

--- a/react-app/src/components/ErrorAlert.module.css
+++ b/react-app/src/components/ErrorAlert.module.css
@@ -1,0 +1,78 @@
+.error {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  width: 450px;
+  padding: 12px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: start;
+  border-radius: 50px;
+  background: -webkit-linear-gradient(to right, #f45c43, #eb3349);
+  background: linear-gradient(to right, #f45c43, #eb3349);
+  box-shadow: 0 0px 10px #de1c3280;
+  position: fixed; /* 화면 상단에 고정 */
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  animation: fadeIn 0.5s ease-in-out;
+}
+
+.error__icon {
+  width: 20px;
+  height: 20px;
+  transform: translateY(-2px);
+  margin-right: 8px;
+  filter: drop-shadow(2px 1px 2px rgb(0 0 0 / 0.4));
+}
+
+.error__icon path {
+  fill: #fff;
+}
+
+.error__title {
+  font-weight: 500;
+  font-size: 14px;
+  color: #fff;
+}
+
+.error__close {
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  margin-left: auto;
+  filter: drop-shadow(2px 1px 2px rgb(0 0 0 / 0.4));
+}
+
+.error__close path {
+  fill: #fff;
+}
+
+/* 애니메이션 추가 */
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-20px);
+  }
+}
+
+/* 경고창 사라지는 효과를 위한 클래스 */
+.fade-out {
+  animation: fadeOut 0.5s ease-in-out forwards;
+}

--- a/react-app/src/mocks/analysis.json
+++ b/react-app/src/mocks/analysis.json
@@ -18,7 +18,7 @@
       "title": "AI Revolutionizing Cancer Treatment",
       "summary": "AI technology is bringing revolutionary changes in cancer treatment and accelerating the development of new treatments.",
       "summary-kor": "AI 기술이 암 치료를 혁신하며 새로운 치료법 개발 속도를 크게 향상시키고 있습니다.",
-      "accuracy": 82,
+      "accuracy": 47,
       "originalArticle": {
         "title": "AI Revolutionizing Cancer Treatment",
         "image": "/src/assets/images/news2.png",

--- a/react-app/src/pages/AnalysisPage.jsx
+++ b/react-app/src/pages/AnalysisPage.jsx
@@ -6,6 +6,7 @@ import '../components/layout/AnalysisPage.module.css';
 import Navbar from '../components/layout/Navbar.jsx';
 import { useEffect, useState } from 'react';
 import Loader from '../components/Loader.jsx'; // 로딩 컴포넌트 임포트
+import ErrorAlert from '../components/ErrorAlert.jsx'; // 경고창 컴포넌트 임포트
 
 async function getAnalitics() { // fetch 쿼리문
     const res = await fetch("http://localhost:5173/analysis");
@@ -24,6 +25,7 @@ const AnalysisPage = () => {
     const [selectedData, setSelectedData] = useState(null); // 선택된 뉴스 데이터
     const [displayedSummary, setDisplayedSummary] = useState('');
     const [loading, setLoading] = useState(true); // 로딩 상태 추가
+    const [showWarning, setShowWarning] = useState(false); // 경고창 상태 추가
 
     useEffect(() => {
         const fetchData = async () => {
@@ -37,6 +39,11 @@ const AnalysisPage = () => {
                 if (selected) {
                     setSelectedData(selected); // 선택된 데이터 설정
                     setDisplayedSummary(selected.summary); // 초기 요약 설정
+
+                    // 정확도가 50% 미만인 경우 경고창 표시
+                    if (selected.accuracy < 50) {
+                      setShowWarning(true);
+                  }
                 }
             } catch (error) {
                 console.error("Error fetching data:", error);
@@ -69,6 +76,10 @@ const AnalysisPage = () => {
     }, 500);
   };
 
+  const handleCloseWarning = () => {
+    setShowWarning(false); // 경고창 닫기
+  };
+
   if (loading) {
     return <Loader />; // 로딩 컴포넌트를 표시
   }
@@ -85,6 +96,14 @@ const AnalysisPage = () => {
     <div className="min-h-screen bg-background">
       {/* Navbar 사용 */}
       <Navbar />
+
+      {/* 경고창 표시 */}
+      {showWarning && (
+        <ErrorAlert
+          message="해당 기사는 정확도가 낮아 신뢰도가 떨어질 수 있습니다."
+          onClose={handleCloseWarning}
+        />
+      )}
 
       {/* 메인 콘텐츠 영역 */}
       <main className="container mx-auto p-4">


### PR DESCRIPTION
## 변경 사항

신뢰도 50% 미만 기사 로딩시 화면 중앙 상단에 경고창 띄우기

## 테스트 실행

- [x]  👍 Yes
- [ ]  🙅 No, Because they are not neaded
- [ ]  🤯 No, Because I needed help with writing tests

### 테스트 결과
<img width="1285" alt="스크린샷 2024-11-29 03 16 12" src="https://github.com/user-attachments/assets/262a8e77-ffb3-45ec-b3df-778c9a4a4ff9">

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
