### PR TITLE
feat: Accuracy Wave 구현 완료

### DIFF
--- a/react-app/src/components/AccuracyCircle.css
+++ b/react-app/src/components/AccuracyCircle.css
@@ -1,0 +1,78 @@
+.circle-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 200px;
+    width: 200px;
+    position: relative;
+  }
+  
+  .circle {
+    position: relative;
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    overflow: hidden;
+    border: 8px solid rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  }
+  
+  .accuracy-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 24px;
+    font-weight: bold;
+    color: #ffffff;
+    z-index: 10;
+  }
+  
+  .ocean {
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    background: #205295;
+    overflow: hidden;
+    --wave-top: 40%; /* 기본값 */
+  }
+  
+  .wave {
+    background: url(https://s3-us-west-2.amazonaws.com/s.cdpn.io/85486/wave.svg)
+      repeat-x;
+    position: absolute;
+    top: var(--wave-top); /* wave 높이를 동적으로 설정 */
+    width: 6400px;
+    height: 198px;
+    animation: wave 7s cubic-bezier(0.36, 0.45, 0.63, 0.53) infinite;
+    transform: translate3d(0, 0, 0);
+  }
+  
+  .wave:nth-of-type(2) {
+    top: calc(var(--wave-top) + 2%); /* 두 번째 wave는 약간 아래 */
+    animation: wave 7s cubic-bezier(0.36, 0.45, 0.63, 0.53) -0.125s infinite,
+      swell 7s ease -1.25s infinite;
+    opacity: 0.7;
+  }
+  
+  @keyframes wave {
+    0% {
+      margin-left: 0;
+    }
+    100% {
+      margin-left: -1600px;
+    }
+  }
+  
+  @keyframes swell {
+    0%,
+    100% {
+      transform: translate3d(0, -5px, 0); /* 상하 이동 조정 */
+    }
+    50% {
+      transform: translate3d(0, 2px, 0);
+    }
+  }
+  

--- a/react-app/src/components/AccuracyCircle.jsx
+++ b/react-app/src/components/AccuracyCircle.jsx
@@ -1,0 +1,29 @@
+import "./AccuracyCircle.css";
+import PropTypes from "prop-types"; // prop-types 임포트
+
+const AccuracyCircle = ({ accuracy }) => {
+  // wave 높이 계산: accuracy에 비례하여 위치 설정
+  const waveHeight = 100 - accuracy; // accuracy가 높을수록 wave 높이는 낮아짐
+
+  return (
+    <div className="circle-container">
+      <div className="circle">
+        <div
+          className="ocean"
+          style={{ "--wave-top": `${waveHeight}%` }} // CSS 변수로 전달
+        >
+          <div className="wave"></div>
+          <div className="wave"></div>
+        </div>
+        <div className="accuracy-text">{accuracy}%</div>
+      </div>
+    </div>
+  );
+};
+
+// prop-types를 사용한 타입 정의
+AccuracyCircle.propTypes = {
+  accuracy: PropTypes.number.isRequired, // accuracy는 필수 숫자 타입
+};
+
+export default AccuracyCircle;

--- a/react-app/src/pages/AnalysisPage.jsx
+++ b/react-app/src/pages/AnalysisPage.jsx
@@ -7,6 +7,7 @@ import Navbar from '../components/layout/Navbar.jsx';
 import { useEffect, useState } from 'react';
 import Loader from '../components/Loader.jsx'; // 로딩 컴포넌트 임포트
 import ErrorAlert from '../components/ErrorAlert.jsx'; // 경고창 컴포넌트 임포트
+import AccuracyCircle from "../components/AccuracyCircle"; // 정확도 컴포넌트 임포트
 
 async function getAnalitics() { // fetch 쿼리문
     const res = await fetch("http://localhost:5173/analysis");
@@ -139,14 +140,7 @@ const AnalysisPage = () => {
               </CardHeader>
               <CardContent>
                 <div className="flex justify-center">
-                  <div className="relative h-48 w-48">
-                    <div className="absolute inset-0 flex items-center justify-center rounded-full border-8 border-primary/20">
-                      <div className="text-center">
-                        <div className="text-4xl font-bold">{selectedData.accuracy}% {/* 정확도 분석 accuracy */}</div>
-                        <div className="text-sm text-muted-foreground">Accuracy</div>
-                      </div>
-                    </div>
-                  </div>
+                  <AccuracyCircle accuracy={selectedData.accuracy} />
                 </div>
                 <div className="mt-6 flex justify-center gap-4">
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
## 변경 사항

정확도 분석 원 안에 Wave 애니메이션 구현 

## 테스트 실행

- [x]  👍 Yes
- [ ]  🙅 No, Because they are not neaded
- [ ]  🤯 No, Because I needed help with writing tests

### 테스트 결과
- 정확도에 따라 Wave 높이 다르게 설정하였습니다.
<img width="1284" alt="스크린샷 2024-11-29 03 45 30" src="https://github.com/user-attachments/assets/c287f778-3c3d-4ab1-a182-d888fdc3fdec">
<img width="1283" alt="스크린샷 2024-11-29 03 45 56" src="https://github.com/user-attachments/assets/3487a6bd-d076-414b-ae0d-8aa55121304f">


ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
